### PR TITLE
Fix `list_domains(repo::IPCInstancesRepo)` bug concerning missing `-` after year

### DIFF
--- a/src/ipc_instances_repo.jl
+++ b/src/ipc_instances_repo.jl
@@ -72,7 +72,7 @@ function list_collections(repo::IPCInstancesRepo)
 end
 
 function list_domains(repo::IPCInstancesRepo)
-    domains = reduce(vcat, (c .* list_domains(repo, c)
+    domains = reduce(vcat, (c * "-" .* list_domains(repo, c)
                             for c in list_collections(repo)))
     return domains
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,9 @@ using PlanningDomains: clear_cache!, clear_all_caches!
 end
 
 @testset "IPC Instances repository" begin
+    domain_names = list_domains(IPCInstancesRepo)
+    @test !isempty(domain_names)
+    domain = load_domain(IPCInstancesRepo, domain_names[1])
     collection_names = list_collections(IPCInstancesRepo)
     @test !isempty(collection_names)
     domain_names = list_domains(IPCInstancesRepo)


### PR DESCRIPTION
When loading a domain that is retrieved using `list_domains(IPCInstances)`, `load_domain(...)` throws an exception: `Domain name must be in the format 'ipc-YYYY-domain-name'.`

`list_domains(...)` currently returns the names in the format `ipc-YYYYdomain-name`.

I've added a (previously failing) test and a fix.

Note that the full test suite will not run at the moment due to #4.